### PR TITLE
Resolve stdin Promise on end event to support shell redirection

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -103,7 +103,7 @@ function stdin() {
     process.stdin.on("data", (data) => {
       buffer += String(data);
     });
-    process.stdin.on("close", () => {
+    process.stdin.on("end", () => {
       resolve(buffer);
     });
     return buffer;


### PR DESCRIPTION
When redirecting standard input from a file (e.g. < settings.json), Node's process.stdin stream emits an end event upon reaching EOF, but does not emit a close event.

Because stdin() previously only listened for close, reading from file redirection left the Promise permanently unresolved. Node's event loop would drain after end, causing the process to exit silently with status code 0 without producing output.

Listen on the end event instead of close so that both piped input and shell file redirection resolve properly.

Assisted-by: Antigravity:gemini-3.6-flash
Tested-by: Buo-ren Lin <buo.ren.lin@gmail.com>